### PR TITLE
修复EEUI服务器挂掉无法创建项目的bug

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -206,14 +206,6 @@ function initProject(createName) {
                     logger.info(chalk.white(`3. npm run dev`));
                 };
                 
-                // 用户选择GitHub服务器下载，直接拷贝GitHub默认模板(ps: 不再往下执行选示例模板,防止EEUI服务器挂掉)
-                if (_answers.location === 'github') {
-                    nextStep(() => {
-                        finalLog();
-                    });
-                    return
-                }
-
                 initDemo((error, downFile, info) => {
                     if (error) {
                         logger.warn(error);

--- a/cli.js
+++ b/cli.js
@@ -205,6 +205,14 @@ function initProject(createName) {
                     logger.info(chalk.white(`2. npm install`));
                     logger.info(chalk.white(`3. npm run dev`));
                 };
+                
+                // 用户选择GitHub服务器下载，直接拷贝GitHub默认模板(ps: 不再往下执行选示例模板,防止EEUI服务器挂掉)
+                if (_answers.location === 'github') {
+                    nextStep(() => {
+                        finalLog();
+                    });
+                    return
+                }
 
                 initDemo((error, downFile, info) => {
                     if (error) {

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -718,7 +718,7 @@ const utils = {
                     });
                     callback('', array);
                 }else{
-                    callback(data.msg);
+                    callback(data && data.msg || '获取演示模板失败！准备使用默认模板~');
                 }
             });
         }catch (e) {


### PR DESCRIPTION
用户选择GitHub服务器下载，直接拷贝GitHub默认模板(ps: 不再往下执行选示例模板,防止EEUI服务器挂掉)